### PR TITLE
Properly depend on homebrew jq formula

### DIFF
--- a/Formula/faq.rb
+++ b/Formula/faq.rb
@@ -1,17 +1,21 @@
-require "formula"
-
 class Faq < Formula
   desc "Format Agnostic jQ"
   homepage "https://github.com/jzelinskie/faq"
-  url "https://github.com/jzelinskie/faq/releases/download/0.0.7/faq-darwin-amd64"
-  sha256 "869f4d8acaa1feb11ce76b2204c5476b8a04d9451216adde6b18e2ef2f978794"
+  url "https://github.com/jzelinskie/faq/archive/refs/tags/0.0.7.tar.gz"
+  sha256 "92ea8718cb9734acf1feccfc9eaa8d54809cb7bd49561ee684fb5f60460dbb83"
   version "0.0.7"
 
   depends_on "jq"
+  depends_on "go" => ":build"
 
   def install
-    system "mv", "faq-darwin-amd64", "faq"
-    bin.install "faq"
+    ENV["CGO_LDFLAGS"] = "-I#{Formula["jq"].opt_lib}"
+    ENV["CGO_CFLAGS"] = "-I#{Formula["jq"].opt_include}"
+    ldflags= %W[
+      -s -w
+      -X github.com/jzelinskie/faq/pkg/version.Version=#{version}
+    ]
+    system "go", "build", "-v", *std_go_args(ldflags: ldflags), "./cmd/faq/main.go"
   end
 
   test do


### PR DESCRIPTION
The pre-built binary the formula downloaded is broken when used on newer macs where the homebrew prefix is not `/usr/local` but `/opt/homebrew`.

The formula should rely on homebrew telling where the library is, and build with CGO using that info.

To avoid incompatible installs, use the `bottle` mechanism of homebrew to fetch prebuilt packages (eg. for older macos versions and architectures), and leave installation by rebuilds open to newer architectures not having prebuilt bottles.

Fixes https://github.com/jzelinskie/faq/issues/100